### PR TITLE
decode multisig transactions data

### DIFF
--- a/dapp/config.js
+++ b/dapp/config.js
@@ -2,6 +2,7 @@ var txDefaultOrig =
 {
   gasLimit: 3141592,
   gasPrice: 18000000000,
+  confirmAddGas: 37004,
   path: "44'/60'/0'/0",
   ethereumNode: "https://mainnet.infura.io:443",
   alertNode: {

--- a/dapp/config.js
+++ b/dapp/config.js
@@ -2,6 +2,7 @@ var txDefaultOrig =
 {
   gasLimit: 3141592,
   gasPrice: 18000000000,
+  path: "44'/60'/0'/0",
   ethereumNode: "https://mainnet.infura.io:443",
   alertNode: {
     url : "https://alerts.gnosis.pm",

--- a/dapp/config.js
+++ b/dapp/config.js
@@ -148,6 +148,7 @@ var txDefault = {
       managementPage: "https://testalerts.gnosis.pm/api/alert/manage/?code={auth-code}"
     }
   },
+  etherscanApiKey: '5HX5Z25IG7PGQ7BGCY3DTJ11MS2VE4Y1MK',
   walletFactoryAddresses: {
     'mainnet': {
       name: 'Mainnet',

--- a/dapp/config.js
+++ b/dapp/config.js
@@ -19,7 +19,7 @@ var txDefaultOrig =
   defaultChainID: null,
   // Mainnet
   walletFactoryAddress: "0x12ff9a987c648c5608b2c2a76f58de74a3bf1987",
-  //ledgerAPI: "http://localhost:" + ledgerPort,
+  ledgerAPI: "http://localhost:" + ledgerPort,
   tokens: [
     {
       'address': '0x6810e776880c02933d47db1b9fc05908e5386b96',

--- a/dapp/controllers/sendTransactionCtrl.js
+++ b/dapp/controllers/sendTransactionCtrl.js
@@ -14,7 +14,7 @@
         Object.assign(tx, $scope.tx);
         var params = [];
         Object.assign(params, $scope.params);
-        if ($scope.method.inputs && $scope.method.inputs.length) {
+        if ($scope.method && $scope.method.inputs && $scope.method.inputs.length) {
           // assign default value (otherwise transaction will fail when any value is not filled)
           for (var i = 0; i < $scope.method.inputs.length; i++) {
             params[i] = params[i] || ""

--- a/dapp/controllers/sendTransactionCtrl.js
+++ b/dapp/controllers/sendTransactionCtrl.js
@@ -2,7 +2,7 @@
   function () {
     angular
     .module("multiSigWeb")
-    .controller("sendTransactionCtrl", function ($scope, Wallet, Utils, Transaction, $uibModalInstance, ABI, Web3Service) {
+    .controller("sendTransactionCtrl", function ($scope, $http, Config, Wallet, Utils, Transaction, $uibModalInstance, ABI, Web3Service) {
       $scope.methods = [];
       $scope.tx = {
         value: 0
@@ -14,6 +14,12 @@
         Object.assign(tx, $scope.tx);
         var params = [];
         Object.assign(params, $scope.params);
+        if ($scope.method.inputs && $scope.method.inputs.length) {
+          // assign default value (otherwise transaction will fail when any value is not filled)
+          for (var i = 0; i < $scope.method.inputs.length; i++) {
+            params[i] = params[i] || ""
+          }
+        }
         if ($scope.method) {
           params.map(function(param, index) {
             // Parse if array param
@@ -174,6 +180,23 @@
             $scope.abi = JSON.stringify($scope.abis[to].abi);
             $scope.name = $scope.abis[to].name;
             $scope.updateMethods();
+          } else {
+            // try to fetch from etherscan
+            Transaction.getEthereumChain().then(
+              function (data) {
+                var config = Config.getUserConfiguration()
+                var etherscanApiKey = config.etherscanApiKey
+                var etherscanApiBaseUrl = data.etherscanApi
+                $http.get(etherscanApiBaseUrl + '/api?module=contract&action=getabi&address=' + to + '&apikey=' + etherscanApiKey)
+                  .then(function (response) {
+                    if (response.data.message === 'OK') {
+                      $scope.abi = response.data.result
+                      $scope.updateMethods();
+                      // save for next time
+                      ABI.update($scope.abiArray, to, $scope.name)
+                    }
+                  })
+              })
           }
         }
       };

--- a/dapp/controllers/walletCtrl.js
+++ b/dapp/controllers/walletCtrl.js
@@ -330,6 +330,19 @@
         });
       };
 
+      $scope.withdrawEther = function (wallet) {
+        $uibModal.open({
+          templateUrl: 'partials/modals/withdrawEther.html',
+          size: 'md',
+          resolve: {
+            wallet: function () {
+              return wallet;
+            }
+          },
+          controller: 'withdrawEtherCtrl'
+        });
+      };
+
       $scope.openNotifications = function (address) {
         var authCode = txDefault.alertNode.authCode || null;
         var template = 'partials/modals/notificationsSignup.html';

--- a/dapp/controllers/walletDetailCtrl.js
+++ b/dapp/controllers/walletDetailCtrl.js
@@ -343,7 +343,6 @@
                         $scope.transactions[tx].dataDecoded = $scope.getParam($scope.transactions[tx]);
                         if ($scope.transactions[tx].dataDecoded.notDecoded) {
                           // Try fetching from etherscan
-                          console.log('trying to fetch from ETHERSCAN: ', info.to)
                           Transaction.getEthereumChain().then(
                             function (data) {
                               var config = Config.getUserConfiguration()

--- a/dapp/controllers/walletDetailCtrl.js
+++ b/dapp/controllers/walletDetailCtrl.js
@@ -2,7 +2,7 @@
   function () {
     angular
     .module("multiSigWeb")
-    .controller("walletDetailCtrl", function (Web3Service, $scope, $filter, $sce, Wallet, $routeParams, Utils, Transaction, $interval, $uibModal, Token, ABI) {
+    .controller("walletDetailCtrl", function (Web3Service, $scope, $filter, $sce, Wallet, $routeParams, Utils, Transaction, $interval, $uibModal, Token, ABI, Config, $http) {
       $scope.wallet = {};
 
       $scope.$watch(
@@ -341,6 +341,26 @@
                       // Get data info if data has not being decoded, because is a new transactions or we don't have the abi to do it
                       if (!$scope.transactions[tx].dataDecoded || $scope.transactions[tx].dataDecoded.notDecoded || ($scope.transactions[tx].dataDecoded.usedABI && (!savedABI || savedABI.abi ))) {
                         $scope.transactions[tx].dataDecoded = $scope.getParam($scope.transactions[tx]);
+                        if ($scope.transactions[tx].dataDecoded.notDecoded) {
+                          // Try fetching from etherscan
+                          console.log('trying to fetch from ETHERSCAN: ', info.to)
+                          Transaction.getEthereumChain().then(
+                            function (data) {
+                              var config = Config.getUserConfiguration()
+                              var etherscanApiKey = config.etherscanApiKey
+                              var etherscanApiBaseUrl = data.etherscanApi
+                              $http.get(etherscanApiBaseUrl + '/api?module=contract&action=getabi&address=' + info.to + '&apikey=' + etherscanApiKey)
+                                .then(function (response) {
+                                  if (response.data.message === 'OK') {
+                                    // save in local storage
+                                    var abiArray = JSON.parse(response.data.result)
+                                    ABI.update(abiArray, info.to)
+                                    // update table
+                                    $scope.transactions[tx].dataDecoded = $scope.getParam($scope.transactions[tx]);
+                                  }
+                                })
+                            })
+                        }
                       }
                       // If destionation type has not been set
                       if (!$scope.transactions[tx].destination) {

--- a/dapp/controllers/walletTransactionCtrl.js
+++ b/dapp/controllers/walletTransactionCtrl.js
@@ -37,7 +37,7 @@
           $scope.method = $scope.methods[0];
           $scope.abiArray = JSON.parse($scope.abi);
           $scope.abiArray.map(function (item, index) {
-            if (!item.constant && item.name && item.type == "function") {
+            if (item.name && item.type == "function") {
               $scope.methods.push({name: item.name, index: index, inputs: item.inputs});
             }
           });

--- a/dapp/controllers/walletTransactionCtrl.js
+++ b/dapp/controllers/walletTransactionCtrl.js
@@ -6,7 +6,7 @@
   function () {
     angular
     .module("multiSigWeb")
-    .controller("walletTransactionCtrl", function (Web3Service, $scope, Wallet, Transaction, Utils, wallet, $uibModalInstance, ABI) {
+    .controller("walletTransactionCtrl", function (Web3Service, $scope, Wallet, Transaction, Utils, wallet, $uibModalInstance, ABI, Config, $http) {
 
       $scope.wallet = wallet;
       $scope.abiArray = null;
@@ -26,6 +26,23 @@
             $scope.abi = JSON.stringify($scope.abis[to].abi);
             $scope.name = $scope.abis[to].name;
             $scope.updateMethods();
+          } else {
+            // try to fetch from etherscan
+            Transaction.getEthereumChain().then(
+              function (data) {
+                var config = Config.getUserConfiguration()
+                var etherscanApiKey = config.etherscanApiKey
+                var etherscanApiBaseUrl = data.etherscanApi
+                $http.get(etherscanApiBaseUrl + '/api?module=contract&action=getabi&address=' + to + '&apikey=' + etherscanApiKey)
+                  .then(function (response) {
+                    if (response.data.message === 'OK') {
+                      $scope.abi = response.data.result
+                      $scope.updateMethods();
+                      // save for next time
+                      ABI.update($scope.abiArray, to, $scope.name)
+                    }
+                  })
+              })
           }
         }
       };

--- a/dapp/controllers/withdrawEtherCtrl.js
+++ b/dapp/controllers/withdrawEtherCtrl.js
@@ -1,0 +1,78 @@
+/**
+* This controller manages submit new multisig transaction under daily limit
+* using submitTransaction function.
+*/
+(
+  function () {
+    angular
+    .module("multiSigWeb")
+    .controller("withdrawEtherCtrl", function ($scope, Wallet, Transaction, Utils, wallet, $uibModalInstance, Web3Service) {
+
+      $scope.wallet = wallet;
+      $scope.tx = {
+        value: 0,
+        to: Web3Service.coinbase,
+        data: '0x0'
+      };
+
+      $scope.send = function () {
+        var tx = {};
+        Object.assign(tx, $scope.tx);
+        tx.value = new Web3().toBigNumber($scope.tx.value).mul('1e18');
+
+        Wallet.submitTransaction(
+          $scope.wallet.address,
+          tx,
+          null,
+          null,
+          null,
+          {onlySimulate: false},
+          function (e, tx) {
+            if (e) {
+              Utils.dangerAlert(e);
+            }
+            else {
+              Utils.notification("Multisig transaction was sent.");
+              Transaction.add(
+                {
+                  txHash: tx,
+                  callback: function () {
+                    Utils.success("Multisig transaction was mined");
+                  }
+                }
+              );
+              $uibModalInstance.close();
+            }
+          }
+        );
+      };
+
+      $scope.signOff = function () {
+        var tx = {};
+        Object.assign(tx, $scope.tx);
+        tx.value = new Web3().toBigNumber($scope.tx.value).mul('1e18');
+
+        Wallet.signTransaction(
+          $scope.wallet.address,
+          tx,
+          null,
+          null,
+          null,
+          function (e, tx) {
+            if (e) {
+              Utils.dangerAlert(e);
+            }
+            else{
+              $uibModalInstance.close();
+              Utils.signed(tx);
+            }
+          }
+        );
+      };
+
+      $scope.cancel = function () {
+        $uibModalInstance.dismiss();
+      };
+    });
+  }
+)();

--- a/dapp/css/gnosis-bootstrap.css
+++ b/dapp/css/gnosis-bootstrap.css
@@ -1586,7 +1586,7 @@ pre code {
 }
 @media (min-width: 1200px) {
   .container {
-    width: 1170px;
+    width: 1370px;
   }
 }
 .container-fluid {
@@ -6594,7 +6594,7 @@ button.close {
     display: inline-block !important;
   }
 }
-@media (min-width: 992px) and (max-width: 1199px) {
+@media (min-width: 992px) and (max-width: 1499px) {
   .visible-md {
     display: block !important;
   }

--- a/dapp/index.html
+++ b/dapp/index.html
@@ -106,6 +106,7 @@
     <script src="./controllers/signOfflineCtrl.js"></script>
     <script src="./controllers/executeTransactionCtrl.js"></script>
     <script src="./controllers/withdrawLimitCtrl.js"></script>
+    <script src="./controllers/withdrawEtherCtrl.js"></script>
     <script src="./controllers/settingsCtrl.js"></script>
     <script src="./controllers/exportWalletConfigCtrl.js"></script>
     <script src="./controllers/importWalletConfigCtrl.js"></script>

--- a/dapp/index.html
+++ b/dapp/index.html
@@ -168,13 +168,21 @@
             </ul>
             <ul class="nav navbar-nav pull-right">
               <li uib-dropdown>
-               <a href="#" uib-dropdown-toggle ng-show="loggedIn">
+               <a href="#" uib-dropdown-toggle ng-show="loggedIn" id="accountInfo" data-clipboard-text={{coinbase}}>
                  <!-- <i class="fa fa-address-book-o" aria-hidden="true"></i> -->
                  Account: {{coinbase|limitTo:20}}... <b class="caret"></b>
                </a>
                <ul class="dropdown-menu">
                   <li ng-repeat="account in accounts"><a href="" ng-click="selectAccount(account)">{{account}}</a></li>
                </ul>
+              </li>
+              
+              <li ng-show="loggedIn">
+                <p style="margin:10px;" class="navbar-text">
+                  <button type="button" class="btn btn-default btn-sm pull-left ng-isolate-scope" data-clipboard-text={{coinbase}} ngclipboard>
+                    Copy
+                  </button>
+                </p>
               </li>
               <li ng-show="loggedIn">
                 <p class="navbar-text" ng-show="balance"> Balance: {{balance|ether}} </p>

--- a/dapp/main.js
+++ b/dapp/main.js
@@ -184,6 +184,111 @@ function restServerSetup () {
 /**
 *
 */
+const template = [
+  {
+    label: 'Edit',
+    submenu: [
+      {role: 'undo'},
+      {role: 'redo'},
+      {type: 'separator'},
+      {role: 'cut'},
+      {role: 'copy'},
+      {role: 'paste'},
+      {role: 'pasteandmatchstyle'},
+      {role: 'delete'},
+      {role: 'selectall'}
+    ]
+  },
+  {
+    label: 'View',
+    submenu: [
+      {role: 'reload'},
+      {role: 'forcereload'},
+      {role: 'toggledevtools'},
+      {type: 'separator'},
+      {role: 'resetzoom'},
+      {role: 'zoomin'},
+      {role: 'zoomout'},
+      {type: 'separator'},
+      {role: 'togglefullscreen'}
+    ]
+  },
+  {
+    role: 'window',
+    submenu: [
+      {role: 'minimize'},
+      {role: 'close'}
+    ]
+  },
+  // {
+  //   label: 'Development',
+  //   submenu: [
+  //     {
+  //       label: "Show DevTools",
+  //       click () {
+  //         if(mainWindow.webContents.isDevToolsOpened()) {
+  //            mainWindow.webContents.closeDevTools()
+
+  //         } 
+  //         else {
+
+  //           mainWindow.webContents.openDevTools();
+  //         } 
+  //       }
+  //     }
+  //   ]
+  // },
+  {
+    role: 'help',
+    submenu: [
+      {
+        label: 'Learn More',
+        click () { require('electron').shell.openExternal('https://electron.atom.io') }
+      }
+    ]
+  }
+]
+
+if (process.platform === 'darwin') {
+  template.unshift({
+    label: app.getName(),
+    submenu: [
+      {role: 'about'},
+      {type: 'separator'},
+      {role: 'services', submenu: []},
+      {type: 'separator'},
+      {role: 'hide'},
+      {role: 'hideothers'},
+      {role: 'unhide'},
+      {type: 'separator'},
+      {role: 'quit'}
+    ]
+  })
+
+  // Edit menu
+  template[1].submenu.push(
+    {type: 'separator'},
+    {
+      label: 'Speech',
+      submenu: [
+        {role: 'startspeaking'},
+        {role: 'stopspeaking'}
+      ]
+    }
+  )
+
+  // Window menu
+  template[3].submenu = [
+    {role: 'close'},
+    {role: 'minimize'},
+    {role: 'zoom'},
+    {type: 'separator'},
+    {role: 'front'}
+  ]
+}
+
+
+
 function createWindow () {
   // Create the browser window.
   mainWindow = new BrowserWindow(
@@ -202,7 +307,7 @@ function createWindow () {
   }));
 
   // Open the DevTools.
-  mainWindow.webContents.openDevTools();
+  //mainWindow.webContents.openDevTools();
 
   // Declare context menus
   const selectionMenu = Menu.buildFromTemplate([
@@ -222,6 +327,7 @@ function createWindow () {
     {role: 'selectall'},
   ]);
 
+  
   // Set up context menu
   mainWindow.webContents.on('context-menu', (e, props) => {
     const { selectionText, isEditable } = props;
@@ -252,6 +358,9 @@ function createWindow () {
     module.paths.push(path.resolve(__dirname, '..', '..', 'app.asar', 'node_modules'));
     path = undefined;
   `);*/
+
+  const menu = Menu.buildFromTemplate(template)
+  Menu.setApplicationMenu(menu)
 }
 
 // This method will be called when Electron has finished

--- a/dapp/main.js
+++ b/dapp/main.js
@@ -134,7 +134,7 @@ function restServerSetup () {
           const hex = tx.serialize().toString("hex");
 
           // Pass to _ledger for signing
-          eth.signTransaction_async("44'/60'/0'/0", hex)
+          eth.signTransaction_async(lastPath || "44'/60'/0'/0", hex)
           .then(result => {
               // Store signature in transaction
               tx.v = new Buffer(result.v, "hex");

--- a/dapp/package.json
+++ b/dapp/package.json
@@ -25,7 +25,8 @@
     "package-all": "electron-packager . MultisigWallet --prune --ignore=tests/* --ignore=testrpc.sh --platform=all --out=./dist --overwrite=true --asar=true",
     "build-linux": "build --linux",
     "build-win": "build --win",
-    "build-osx": "build --mac"
+    "build-osx": "build --mac",
+    "postbuild-osx": "codesign -s \"Developer ID Application: Colu technologies Ltd (TCVCLYQVFC)\" --keychain ~/Library/Keychains/login.keychain ./dist/${npm_package_name}-${npm_package_version}.dmg -f --verbose=4"
   },
   "keywords": [
     "ethereum",

--- a/dapp/partials/modals/withdrawEther.html
+++ b/dapp/partials/modals/withdrawEther.html
@@ -1,0 +1,30 @@
+<div class="modal-header">
+  <h3 class="modal-title">
+    Withdraw Ether
+  </h3>
+</div>
+<form name="form" class="form">
+  <div class="modal-body">
+    <div class="form-group">
+      <label for="value">Amount (ETH)</label>
+      <input id="value" type="number" class="form-control" ng-model="tx.value" ng-min="0" max="999999999999999" required>
+    </div>
+    <div class="form-group">
+      <label for="address">Destination</label>
+      <input id="address" type="text" class="form-control" ng-model="tx.to" ng-minlength="40" required>
+    </div>
+  </div>
+  <div class="modal-footer">
+    <button type="button" ng-click="send()" class="btn btn-default" ng-disabled="form.$invalid"
+      disabled-if-invalid-address="{{tx.to}}"
+      show-hide-by-connectivity="online">
+      Send multisig transaction
+    </button>
+    <button type="button" ng-click="signOff()" class="btn btn-default" ng-disabled="form.$invalid" show-hide-by-connectivity="offline">
+      Sign offline
+    </button>
+    <button type="button" ng-click="cancel()" class="btn btn-danger">
+      Cancel
+    </button>
+  </div>
+</form>

--- a/dapp/partials/settings.html
+++ b/dapp/partials/settings.html
@@ -77,6 +77,10 @@
             type="contract-address">
           </editable-select>
         </div>
+        <div class="col-md-6 form-group">
+          <label for="path">Path</label>
+          <input id="path" type="string" ng-model="config.path" class="form-control" />
+        </div>
       </div>
     </div>
     <div class="panel-footer">

--- a/dapp/partials/wallets.html
+++ b/dapp/partials/wallets.html
@@ -68,9 +68,15 @@
           <span value-or-dash-by-connectivity="{{wallet.balance|ether}}">{{wallet.balance|ether}}</span>
           <button type="button" disabled-if-no-accounts-or-wallet-available="{{wallet.address}}"
             class="btn btn-default btn-sm pull-right"
+            ng-click="withdrawEther(wallet)">
+            Withdraw
+          </button>
+          <button type="button" disabled-if-no-accounts-or-wallet-available="{{wallet.address}}"
+            class="btn btn-default btn-sm pull-right"
             ng-click="deposit(wallet)">
             Deposit
           </button>
+          
         </td>
         <td>
           <span class="col-xs-9" value-or-dash-by-connectivity="{{wallet.confirmations|bigNumber|dashIfEmpty}}"></span>

--- a/dapp/services/Transaction.js
+++ b/dapp/services/Transaction.js
@@ -305,6 +305,7 @@
                 else if (block && block.hash == "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3") {
                   data.chain = "mainnet";
                   data.etherscan = "https://etherscan.io";
+                  data.etherscanApi = "https://api.etherscan.io";
                   data.walletFactoryAddress = "0xed5a90efa30637606ddaf4f4b3d42bb49d79bd4e";
                 }
                 else if (block && block.hash == "0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d") {
@@ -322,6 +323,8 @@
                   data.etherscan = "https://testnet.etherscan.io";
                   data.walletFactoryAddress = "0xd79426bcee5b46fde413ededeb38364b3e666097";
                 }
+
+                data.etherscanApi = data.etherscanApi || data.etherscan
 
                 resolve(data);
               });

--- a/dapp/services/Wallet.js
+++ b/dapp/services/Wallet.js
@@ -24,7 +24,9 @@
         abiDecoder.addABI(abi);
       };
 
-      wallet.mergedABI = wallet.json.multiSigDailyLimit.abi.concat(wallet.json.multiSigDailyLimitFactory.abi).concat(wallet.json.token.abi);
+      wallet.mergedABI = Object.keys(wallet.json).map(key => wallet.json[key].abi).reduce((accAbiArray, currentAbiArray) => {
+        return accAbiArray.concat(currentAbiArray)
+      })
 
       // Concat cached abis
       var cachedABIs = ABI.get();

--- a/dapp/services/Wallet.js
+++ b/dapp/services/Wallet.js
@@ -11,7 +11,8 @@
         txParams: {
           nonce: null,
           gasPrice: txDefault.gasPrice,
-          gasLimit: txDefault.gasLimit
+          gasLimit: txDefault.gasLimit,
+          confirmAddGas: txDefault.confirmAddGas
         },
         accounts: [],
         methodIds: {},
@@ -74,6 +75,8 @@
         var txParams = {
           gasPrice: EthJS.Util.intToHex(wallet.txParams.gasPrice),
           gas: EthJS.Util.intToHex(wallet.txParams.gasLimit),
+          confirmAddGas: wallet.txParams.confirmAddGas,
+          confirmAddGasHex: EthJS.Util.intToHex(wallet.txParams.confirmAddGas),
           from: Web3Service.coinbase
         };
 
@@ -1033,13 +1036,18 @@
           to: address,
           data: instance.confirmTransaction.getData(txId)
         }, function (err, gas) {
+          if(defaults.confirmAddGas) {
+           console.log("adding gas: ", defaults.confirmAddGas)
+           console.log("computed gas: ", gas)
+           console.log("total gas: ", gas + defaults.confirmAddGas)
+          }
           Web3Service.sendTransaction(
             instance.confirmTransaction,
             [
               txId,
               {
                 gasPrice: defaults.gasPrice,
-                gas: gas,
+                gas: gas + defaults.confirmAddGas,
                 from: defaults.from
               }
             ],

--- a/dapp/services/Wallet.js
+++ b/dapp/services/Wallet.js
@@ -1027,15 +1027,26 @@
       */
       wallet.confirmTransaction = function (address, txId, options, cb) {
         var instance = Web3Service.web3.eth.contract(wallet.json.multiSigDailyLimit.abi).at(address);
-        Web3Service.sendTransaction(
-          instance.confirmTransaction,
-          [
-            txId,
-            wallet.txDefaults()
-          ],
-          options,
-          cb
-        );
+        var defaults = wallet.txDefaults()
+        Web3Service.web3.eth.estimateGas({
+          from: defaults.from,
+          to: address,
+          data: instance.confirmTransaction.getData(txId)
+        }, function (err, gas) {
+          Web3Service.sendTransaction(
+            instance.confirmTransaction,
+            [
+              txId,
+              {
+                gasPrice: defaults.gasPrice,
+                gas: gas,
+                from: defaults.from
+              }
+            ],
+            options,
+            cb
+          );
+        })
       };
 
       /**

--- a/dapp/services/Web3Service.js
+++ b/dapp/services/Web3Service.js
@@ -195,7 +195,7 @@
 
         var web3Provider = new HookedWeb3Provider({
           getAccounts: function (cb) {
-            $http.get(txDefault.ledgerAPI + "/accounts").success(function (accounts) {
+            $http.get(txDefault.ledgerAPI + "/accounts/" + encodeURIComponent(txDefault.path)).success(function (accounts) {
               cb(null, accounts);
             }).error(cb);
           },

--- a/dapp/services/Web3Service.js
+++ b/dapp/services/Web3Service.js
@@ -230,6 +230,7 @@
                     cb(e);
                   }
                   else {
+                    console.log("getNetwork chainID", chainID)
                     sendToLedger(chainID);
                   }
                 });


### PR DESCRIPTION
Following enhancements were implemented:
1. When reaching "Send multisig transaction" modal (Wallets -> Multisig Transactions -> Add):
   After initially filling destination address, if destination is a contract and its ABI not already loaded into local storage **there will be an attempt to fetch it from etherscan**.
2. In Multisig transactions "Data/Subject" column, the transaction data will be decoded according to:
   a. A pre-loaded ABI from `abi.js`.
   b. If a failed, ABI fetched from etherscan.