### PR TITLE
Workaround for Solidity padding data in the low-level call function

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity ^0.4.15;
 
 contract Migrations {
   address public owner;

--- a/contracts/MultiSigWallet.sol
+++ b/contracts/MultiSigWallet.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity ^0.4.15;
 
 
 /// @title Multisignature wallet - Allows multiple parties to agree on transactions before execution.
@@ -230,13 +230,35 @@ contract MultiSigWallet {
         if (isConfirmed(transactionId)) {
             Transaction storage txn = transactions[transactionId];
             txn.executed = true;
-            if (txn.destination.call.value(txn.value)(txn.data))
+            if (external_call(txn.destination, txn.value, txn.data.length, txn.data))
                 Execution(transactionId);
             else {
                 ExecutionFailure(transactionId);
                 txn.executed = false;
             }
         }
+    }
+
+    // call has been separated into its own function in order to take advantage
+    // of the Solidity's code generator to produce a loop that copies tx.data into memory.
+    function external_call(address destination, uint value, uint dataLength, bytes data) private returns (bool) {
+        bool result;
+        assembly {
+            let x := mload(0x40)   // "Allocate" memory for output (0x40 is where "free memory" pointer is stored by convention)
+            let d := add(data, 32) // First 32 bytes are the padded length of data, so exclude that
+            result := call(
+                sub(gas, 34710),   // 34710 is the value that solidity is currently emitting
+                                   // It includes callGas (700) + callVeryLow (3, to pay for SUB) + callValueTransferGas (9000) +
+                                   // callNewAccountGas (25000, in case the destination address does not exist and needs creating)
+                destination,
+                value,
+                d,
+                dataLength,        // Size of the input (in bytes) - this is what fixes the padding problem
+                x,
+                0                  // Output is ignored, therefore the output size is zero
+            )
+        }
+        return result;
     }
 
     /// @dev Returns the confirmation status of a transaction.

--- a/contracts/MultiSigWalletFactory.sol
+++ b/contracts/MultiSigWalletFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity ^0.4.15;
 import "./Factory.sol";
 import "./MultiSigWallet.sol";
 

--- a/contracts/MultiSigWalletWithDailyLimit.sol
+++ b/contracts/MultiSigWalletWithDailyLimit.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity ^0.4.15;
 import "./MultiSigWallet.sol";
 
 

--- a/contracts/MultiSigWalletWithDailyLimitFactory.sol
+++ b/contracts/MultiSigWalletWithDailyLimitFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity ^0.4.15;
 import "./Factory.sol";
 import "./MultiSigWalletWithDailyLimit.sol";
 

--- a/contracts/TestCalls.sol
+++ b/contracts/TestCalls.sol
@@ -1,0 +1,43 @@
+pragma solidity ^0.4.15;
+
+
+/// @title Contract for testing low-level calls issued from the multisig wallet
+contract TestCalls {
+
+	// msg.data.length of the latest call to "receive" methods
+	uint public lastMsgDataLength;
+
+	// msg.value of the latest call to "receive" methods
+	uint public lastMsgValue;
+
+	uint public uint1;
+	uint public uint2;
+	bytes public byteArray1;
+
+	modifier setMsgFields {
+		lastMsgDataLength = msg.data.length;
+		lastMsgValue = msg.value;
+		_;
+	}
+
+	function TestCalls() setMsgFields public {
+		// This constructor will be used to test the creation via multisig wallet
+	}
+
+	function receive1uint(uint a) setMsgFields payable public {
+		uint1 = a;
+	}
+
+	function receive2uints(uint a, uint b) setMsgFields payable public {
+		uint1 = a;
+		uint2 = b;
+	}
+
+	function receive1bytes(bytes c) setMsgFields payable public {
+		byteArray1 = c;
+	}
+
+	function nonPayable() setMsgFields public {
+	}
+
+}

--- a/contracts/TestToken.sol
+++ b/contracts/TestToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity ^0.4.15;
 
 
 /// @title Test token contract - Allows testing of token transfers with multisig wallet.
@@ -37,11 +37,20 @@ contract TestToken {
         totalSupply += _value;
     }
 
+    /*
+     * This modifier is present in some real world token contracts, and due to a solidity
+     * bug it was not compatible with multisig wallets
+     */
+    modifier onlyPayloadSize(uint size) {
+        require(msg.data.length == size + 4);
+        _;
+    }
+
     /// @dev Transfers sender's tokens to a given address. Returns success.
     /// @param _to Address of token receiver.
     /// @param _value Number of tokens to transfer.
     /// @return Returns success of function call.
-    function transfer(address _to, uint256 _value)
+    function transfer(address _to, uint256 _value) onlyPayloadSize(2 * 32)
         public
         returns (bool success)
     {

--- a/test/javascript/testExternalCalls.js
+++ b/test/javascript/testExternalCalls.js
@@ -1,0 +1,178 @@
+const MultiSigWallet = artifacts.require('MultiSigWallet')
+const web3 = MultiSigWallet.web3
+const TestToken = artifacts.require('TestToken')
+const TestCalls = artifacts.require('TestCalls')
+
+const deployMultisig = (owners, confirmations) => {
+    return MultiSigWallet.new(owners, confirmations)
+}
+const deployToken = () => {
+	return TestToken.new()
+}
+const deployCalls = () => {
+	return TestCalls.new()
+}
+
+const utils = require('./utils')
+
+contract('MultiSigWallet', (accounts) => {
+    let multisigInstance
+    let tokenInstance
+    let callsInstance
+    const requiredConfirmations = 2
+
+    beforeEach(async () => {
+        multisigInstance = await deployMultisig([accounts[0], accounts[1]], requiredConfirmations)
+        assert.ok(multisigInstance)
+        tokenInstance = await deployToken()
+        assert.ok(tokenInstance)
+        callsInstance = await deployCalls()
+        assert.ok(callsInstance)
+
+        const deposit = 10000000
+
+        // Send money to wallet contract
+        await new Promise((resolve, reject) => web3.eth.sendTransaction({to: multisigInstance.address, value: deposit, from: accounts[0]}, e => (e ? reject(e) : resolve())))
+        const balance = await utils.balanceOf(web3, multisigInstance.address)
+        assert.equal(balance.valueOf(), deposit)
+    })
+
+    it('transferWithPayloadSizeCheck', async () => {
+        // Issue tokens to the multisig address
+        const issueResult = await tokenInstance.issueTokens(multisigInstance.address, 1000000, {from: accounts[0]})
+        assert.ok(issueResult)
+        // Encode transfer call for the multisig
+        const transferEncoded = tokenInstance.contract.transfer.getData(accounts[1], 1000000)
+        const transactionId = utils.getParamFromTxEvent(
+            await multisigInstance.submitTransaction(tokenInstance.address, 0, transferEncoded, {from: accounts[0]}),
+            'transactionId', null, 'Submission')
+
+        const executedTransactionId = utils.getParamFromTxEvent(
+            await multisigInstance.confirmTransaction(transactionId, {from: accounts[1]}),
+            'transactionId', null, 'Execution')
+        // Check that transaction has been executed
+        assert.ok(transactionId.equals(executedTransactionId))
+        // Check that the transfer has actually occured
+        assert.equal(
+            1000000,
+            await tokenInstance.balanceOf(accounts[1])
+        )
+    })
+
+    it('transferFailure', async () => {
+        // Encode transfer call for the multisig
+        const transferEncoded = tokenInstance.contract.transfer.getData(accounts[1], 1000000)
+        const transactionId = utils.getParamFromTxEvent(
+            await multisigInstance.submitTransaction(tokenInstance.address, 0, transferEncoded, {from: accounts[0]}),
+            'transactionId', null, 'Submission')
+        // Transfer without issuance - expected to fail
+        const failedTransactionId = utils.getParamFromTxEvent(
+            await multisigInstance.confirmTransaction(transactionId, {from: accounts[1]}),
+            'transactionId', null, 'ExecutionFailure')
+        // Check that transaction has been executed
+        assert.ok(transactionId.equals(failedTransactionId))
+    })
+
+    // The test below can only work if the Multisig wallet allows non-zero destinations (that enables creation of contracts)
+    // This is mainly to test the gas dynamics between the multisig and the callee contract
+    /*
+    it('createTestCalls', async () => {
+        const transactionId = utils.getParamFromTxEvent(
+            await multisigInstance.submitTransaction("0x0000000000000000000000000000000000000000", 0, TestCalls.binary, {from: accounts[0]}),
+            'transactionId', null, 'Submission')
+        execResult = await multisigInstance.confirmTransaction(transactionId, {from: accounts[1]})
+        // Could not find a way to extract the receipt from the nested transaction to obtain the created contract address
+        const executedTransactionId = utils.getParamFromTxEvent(execResult, 'transactionId', null, 'Execution')
+        // Check that transaction has been executed
+        assert.ok(transactionId.equals(executedTransactionId))
+    })
+    */
+
+    it('callReceive1uint', async() => {
+         // Encode call for the multisig
+        const receive1uintEncoded = callsInstance.contract.receive1uint.getData(12345)
+        const transactionId = utils.getParamFromTxEvent(
+            await multisigInstance.submitTransaction(callsInstance.address, 67890, receive1uintEncoded, {from: accounts[0]}),
+            'transactionId', null, 'Submission')
+
+        const executedTransactionId = utils.getParamFromTxEvent(
+            await multisigInstance.confirmTransaction(transactionId, {from: accounts[1]}),
+            'transactionId', null, 'Execution')
+        // Check that transaction has been executed
+        assert.ok(transactionId.equals(executedTransactionId))
+        // Check that the expected parameters and values were passed
+        assert.equal(
+            12345,
+            await callsInstance.uint1()
+        )
+        assert.equal(
+            32 + 4,
+            await callsInstance.lastMsgDataLength()
+        )
+        assert.equal(
+            67890,
+            await callsInstance.lastMsgValue()
+        )
+    })
+
+    it('callReceive2uint', async() => {
+         // Encode call for the multisig
+        const receive2uintsEncoded = callsInstance.contract.receive2uints.getData(12345, 67890)
+        const transactionId = utils.getParamFromTxEvent(
+            await multisigInstance.submitTransaction(callsInstance.address, 4040404, receive2uintsEncoded, {from: accounts[0]}),
+            'transactionId', null, 'Submission')
+
+        const executedTransactionId = utils.getParamFromTxEvent(
+            await multisigInstance.confirmTransaction(transactionId, {from: accounts[1]}),
+            'transactionId', null, 'Execution')
+        // Check that transaction has been executed
+        assert.ok(transactionId.equals(executedTransactionId))
+        // Check that the expected parameters and values were passed
+        assert.equal(
+            12345,
+            await callsInstance.uint1()
+        )
+         assert.equal(
+            67890,
+            await callsInstance.uint2()
+        )
+        assert.equal(
+            32 + 32 + 4,
+            await callsInstance.lastMsgDataLength()
+        )
+        assert.equal(
+            4040404,
+            await callsInstance.lastMsgValue()
+        )
+    })
+
+    it('callReceive1bytes', async() => {
+         // Encode call for the multisig
+        const dataHex = '0x' + '0123456789abcdef'.repeat(100) // 800 bytes long
+
+        const receive1bytesEncoded = callsInstance.contract.receive1bytes.getData(dataHex)
+        const transactionId = utils.getParamFromTxEvent(
+            await multisigInstance.submitTransaction(callsInstance.address, 10, receive1bytesEncoded, {from: accounts[0]}),
+            'transactionId', null, 'Submission')
+
+        const executedTransactionId = utils.getParamFromTxEvent(
+            await multisigInstance.confirmTransaction(transactionId, {from: accounts[1]}),
+            'transactionId', null, 'Execution')
+        // Check that transaction has been executed
+        assert.ok(transactionId.equals(executedTransactionId))
+        // Check that the expected parameters and values were passed
+        assert.equal(
+            868, // 800 bytes data + 32 bytes offset + 32 bytes data length + 4 bytes method signature
+            await callsInstance.lastMsgDataLength()
+        )
+        assert.equal(
+            10,
+            await callsInstance.lastMsgValue()
+        )
+        assert.equal(
+            dataHex,
+            await callsInstance.byteArray1()
+        )
+    })
+
+})

--- a/truffle_test_runner.sh
+++ b/truffle_test_runner.sh
@@ -3,3 +3,4 @@ truffle compile
 run-with-testrpc -d 'truffle test test/javascript/testMultiSigWalletWithDailyLimit.js'
 run-with-testrpc -d 'truffle test test/javascript/testMultiSigWalletWithDailyLimitFactory.js'
 run-with-testrpc -d 'truffle test test/javascript/testExecutionAfterRequirementsChanged.js'
+run-with-testrpc -d 'truffle test test/javascript/testExternalCalls.js'


### PR DESCRIPTION
Workaround for this issue: https://github.com/ethereum/solidity/issues/2884