### PR TITLE
add tokenFallback function for ERC223 compatibility

### DIFF
--- a/contracts/MultiSigWallet.sol
+++ b/contracts/MultiSigWallet.sol
@@ -99,6 +99,9 @@ contract MultiSigWallet {
             Deposit(msg.sender, msg.value);
     }
 
+    // ERC223 fallback function to accept token transfers
+    function tokenFallback(address, uint, bytes) public {}
+
     /*
      * Public functions
      */


### PR DESCRIPTION
in order to make the Gnosis MultiSig ERC223 compatible the `tokenFallback` function with an empty body does the trick.

This does not impact the functionality of the contract in any way and does not pose a security vulnerability.