### PR TITLE
remove node versions from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 dist: trusty
 language: node_js
 node_js:
-- '7'
-- '8'
 - '9'
 sudo: required
 before_install:

--- a/dapp/package-lock.json
+++ b/dapp/package-lock.json
@@ -10361,7 +10361,7 @@
       }
     },
     "file-saver": {
-      "version": "1.3.3",
+      "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-1.3.3.tgz",
       "integrity": "sha1-zdTETTqiZOrC9o7BZbx5HDSvEjI="
     },
@@ -18043,7 +18043,7 @@
       }
     },
     "ledger-wallet-provider": {
-      "version": "git+https://github.com/denisgranha/ledger-wallet-provider.git#4da77520341aaad434a5538717961b83b57dfdd1",
+      "version": "git+https://github.com/denisgranha/ledger-wallet-provider.git#47abf2dd2c6b726e2c9ac242464df45798b0775e",
       "requires": {
         "babel-loader": "6.4.1",
         "babel-plugin-add-module-exports": "0.2.1",
@@ -19937,8 +19937,7 @@
     },
     "os-tmpdir": {
       "version": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
       "version": "0.0.3",

--- a/dapp/package.json
+++ b/dapp/package.json
@@ -80,7 +80,7 @@
     "http-server": "^0.9.0",
     "jquery": "^3.3.1",
     "json-rpc-error": "^2.0.0",
-    "ledger-wallet-provider": "git+https://github.com/denisgranha/ledger-wallet-provider#1.0.15",
+    "ledger-wallet-provider": "git+https://github.com/denisgranha/ledger-wallet-provider#v1.15.0",
     "ledgerco": "^1.1.2",
     "moment": "^2.17.0",
     "ngclipboard": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
     "install": "cd dapp && npm install",
     "start": "cd dapp && npm start"
   },
-  "engines": {
-    "node": "7.1.0"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/gnosis/MultiSigWallet.git"


### PR DESCRIPTION
Ledger library doesn't allow to increase timeout, new version it's only on node and would mean set up webpack for dependencies or similar, too much work.

If someone needs bigger ledger timeout, better use electron version, doesn't have timeout.