### PR TITLE
Add Streamr DATA to list of default tokens

### DIFF
--- a/dapp/config.js
+++ b/dapp/config.js
@@ -97,6 +97,12 @@ var txDefaultOrig =
       'name': 'Storjcoin X',
       'symbol': 'SJCX',
       'decimals': 8
+    },
+    {
+      'address': '0x0cf0ee63788a0849fe5297f3407f701e122cc023',
+      'name': 'Streamr',
+      'symbol': 'DATA',
+      'decimals': 18
     }
   ]
 };


### PR DESCRIPTION
Hi! Many thanks for creating the multisig wallet UI, we at Streamr have been using it extensively for the past 1.5 years.

Noticed that recent versions of the UI include a list of tokens visible by default in the UI, and many of our friend projects are on the list. With this PR I would like to propose adding Streamr DATA to the list as well.

- Edit `dapp/config.js` to add Streamr DATAcoin (DATA) to the list of default tokens visible in the Tokens section of a wallet.