### PR TITLE
Fix on payload size issue multisig with daily limit

### DIFF
--- a/contracts/MultiSigWallet.sol
+++ b/contracts/MultiSigWallet.sol
@@ -241,7 +241,7 @@ contract MultiSigWallet {
 
     // call has been separated into its own function in order to take advantage
     // of the Solidity's code generator to produce a loop that copies tx.data into memory.
-    function external_call(address destination, uint value, uint dataLength, bytes data) private returns (bool) {
+    function external_call(address destination, uint value, uint dataLength, bytes data) internal returns (bool) {
         bool result;
         assembly {
             let x := mload(0x40)   // "Allocate" memory for output (0x40 is where "free memory" pointer is stored by convention)

--- a/contracts/MultiSigWalletWithDailyLimit.sol
+++ b/contracts/MultiSigWalletWithDailyLimit.sol
@@ -56,7 +56,7 @@ contract MultiSigWalletWithDailyLimit is MultiSigWallet {
             txn.executed = true;
             if (!_confirmed)
                 spentToday += txn.value;
-            if (txn.destination.call.value(txn.value)(txn.data))
+            if (external_call(txn.destination, txn.value, txn.data.length, txn.data))
                 Execution(transactionId);
             else {
                 ExecutionFailure(transactionId);

--- a/test/javascript/testExternalCallsWithDailyLimit.js
+++ b/test/javascript/testExternalCallsWithDailyLimit.js
@@ -1,0 +1,62 @@
+const MultiSigWalletWithDailyLimit = artifacts.require('MultiSigWalletWithDailyLimit')
+const web3 = MultiSigWalletWithDailyLimit.web3
+const TestToken = artifacts.require('TestToken')
+const TestCalls = artifacts.require('TestCalls')
+
+const deployToken = () => {
+	return TestToken.new()
+}
+const deployCalls = () => {
+	return TestCalls.new()
+}
+
+const deployMultisig = (owners, confirmations, limit) => {
+    return MultiSigWalletWithDailyLimit.new(owners, confirmations, limit)
+}
+
+const utils = require('./utils')
+const ONE_DAY = 24*3600
+
+contract('MultiSigWalletWithDailyLimit', (accounts) => {
+    let multisigInstance
+    const dailyLimit = 3000
+    const requiredConfirmations = 2
+
+    beforeEach(async () => {
+        multisigInstance = await deployMultisig([accounts[0], accounts[1]], requiredConfirmations, dailyLimit)
+        assert.ok(multisigInstance)
+        tokenInstance = await deployToken()
+        assert.ok(tokenInstance)
+        callsInstance = await deployCalls()
+        assert.ok(callsInstance)
+
+        const deposit = 10000000
+
+        // Send money to wallet contract
+        await new Promise((resolve, reject) => web3.eth.sendTransaction({to: multisigInstance.address, value: deposit, from: accounts[0]}, e => (e ? reject(e) : resolve())))
+        const balance = await utils.balanceOf(web3, multisigInstance.address)
+        assert.equal(balance.valueOf(), deposit)
+    })
+
+    it('transferWithPayloadSizeCheck', async () => {
+        // Issue tokens to the multisig address
+        const issueResult = await tokenInstance.issueTokens(multisigInstance.address, 1000000, {from: accounts[0]})
+        assert.ok(issueResult)
+        // Encode transfer call for the multisig
+        const transferEncoded = tokenInstance.contract.transfer.getData(accounts[1], 1000000)
+        const transactionId = utils.getParamFromTxEvent(
+            await multisigInstance.submitTransaction(tokenInstance.address, 0, transferEncoded, {from: accounts[0]}),
+            'transactionId', null, 'Submission')
+
+        const executedTransactionId = utils.getParamFromTxEvent(
+            await multisigInstance.confirmTransaction(transactionId, {from: accounts[1]}),
+            'transactionId', null, 'Execution')
+        // Check that transaction has been executed
+        assert.ok(transactionId.equals(executedTransactionId))
+        // Check that the transfer has actually occured
+        assert.equal(
+            1000000,
+            await tokenInstance.balanceOf(accounts[1])
+        )
+    })
+})

--- a/truffle_test_runner.sh
+++ b/truffle_test_runner.sh
@@ -4,3 +4,4 @@ run-with-testrpc -d 'truffle test test/javascript/testMultiSigWalletWithDailyLim
 run-with-testrpc -d 'truffle test test/javascript/testMultiSigWalletWithDailyLimitFactory.js'
 run-with-testrpc -d 'truffle test test/javascript/testExecutionAfterRequirementsChanged.js'
 run-with-testrpc -d 'truffle test test/javascript/testExternalCalls.js'
+run-with-testrpc -d 'truffle test test/javascript/testExternalCallsWithDailyLimit.js'


### PR DESCRIPTION
Hello, 
I noticed that your .*WithDailyLimit MultiSigWallet doesn't have the fix in the executeTransaction for the OnPayloadSize "short address mitigation" which you guys kindly implemented in the main MultiSigWallet ... I would be great if you could get this merged in and release so that no more tokens get stuck needlessly. 

In the first commit, I created a test that showed that the issue is present in the MultiSigWalletWithDailyLimit, in the second commit, I made a 2 line change, I need to change the scope of the external_call method to internal, as the DailyLimit one is a MultiSigWallet and then i copied the line using the external_call over to the DailyLimit. 

Cheers

