### PR TITLE
Allow 0 as nonce for offline transaction

### DIFF
--- a/dapp/src/services/Wallet.js
+++ b/dapp/src/services/Wallet.js
@@ -125,7 +125,7 @@
           value: ethereumjs.Util.intToHex(0),
           gasPrice: ethereumjs.Util.intToHex(wallet.txParams.gasPrice),
           gas: ethereumjs.Util.intToHex(wallet.txParams.gasLimit),
-          nonce: nonce?nonce:ethereumjs.Util.intToHex(wallet.txParams.nonce),
+          nonce: nonce||nonce==0?nonce:ethereumjs.Util.intToHex(wallet.txParams.nonce),
           data: data
         };
 


### PR DESCRIPTION
This pull request fixes the issue that it is not possible to create a offline signature from an address which has no transactions so far (nonce 0)

![GnosisBug2](https://user-images.githubusercontent.com/9080879/57536479-8f42c980-7344-11e9-8e46-ec84edb0a4f4.png)

If you try to sign a tx with nonce 0, it results in the following error and the signing process starts all over again, enter transaction id

![GnosisBug](https://user-images.githubusercontent.com/9080879/57536486-94a01400-7344-11e9-9c7a-8a7ce568b344.png)
