### PR TITLE
Fixed README.md with libusb dev headers + correct nodejs version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Ethereum Multisignature Wallet
 
 The purpose of multisig wallets is to increase security by requiring multiple parties to agree on transactions before execution. Transactions can be executed only when confirmed by a predefined number of owners. A web user interface can be found [here](/dapp).
 
+**NOTE:** Not compatible with current NodeJS LTS. Recommended NodeJS version is v6.17.1 (last LTS for v6).
+
 Features
 -------------
 
@@ -30,8 +32,20 @@ Being used by
 Install
 -------------
 ```
+# For Ubuntu/Debian you need to install libusb development headers
+apt install -y libusb-1.0-0-dev
+
 git clone https://github.com/gnosis/MultiSigWallet.git
 cd MultiSigWallet
+
+# Latest NodeJS (v12.13.0) does NOT appear to work correctly.
+# You should use NVM and install Node v6.17.1 for best results: https://github.com/nvm-sh/nvm
+# Tested by @Privex on 2019-Nov-06 with v6.17.1 with success
+nvm install v6.17.1
+
+# node-gyp is required for 'npm install' to work correctly
+npm install node-gyp
+
 npm install
 ```
 

--- a/dapp/Readme.md
+++ b/dapp/Readme.md
@@ -5,12 +5,26 @@ A web user interface for the [MultiSigWallet](https://github.com/gnosis/MultiSig
 
 Requirements
 -------------
-* Node v5+
+* Node v5+ (Confirmed working on v6.17.1 - will not work on current LTS v12.13.0)
 * [Grunt-cli](http://gruntjs.com/getting-started#installing-the-cli)
 
 Install
 -------------
 ```
+# For Ubuntu/Debian you need to install libusb development headers
+apt install -y libusb-1.0-0-dev
+
+# Latest NodeJS (v12.13.0) does NOT appear to work correctly.
+# You should use NVM and install Node v6.17.1 for best results: https://github.com/nvm-sh/nvm
+# Tested by @Privex on 2019-Nov-06 with v6.17.1 with success
+nvm install v6.17.1
+
+git clone https://github.com/gnosis/MultiSigWallet.git
+cd MultiSigWallet/dapp
+
+# node-gyp is required for 'npm install' to work correctly
+npm install node-gyp
+
 npm install -g grunt-cli
 npm install
 grunt


### PR DESCRIPTION
Possibly fixes issue #313 and fixes issue #290

I had issues trying to run `npm install` on Ubuntu 18.04 Server, and after some trial and error I managed to get it working with the following workarounds:

 - You MUST use an older NodeJS version such as v6.17.1 (last LTS for v6), as the current LTS pf 12.13.0 does NOT work. (this is why [NVM](https://github.com/nvm-sh/nvm) exists)
    - `nvm install v6.17.1`
 - You MUST install `node-gyp` before running `npm install`, otherwise it will fail to compile some of the dependencies and the install will error.
    - `npm install node-gyp`
 - At least on Debian/Ubuntu, you MUST install `libusb-1.0.0-dev` or it will error saying it can't find `libusb.h`
    - `apt install -y libusb-1.0-0-dev`

I've updated the `README.md` and the readme in `dapp/README.md` to make these installation requirements clear, and save others having to figure out why it's broken.