### PR TITLE
(gruntfile) Convert host/port/cert/key into env vars

### DIFF
--- a/dapp/Gruntfile.js
+++ b/dapp/Gruntfile.js
@@ -1,3 +1,8 @@
+const DAPP_PORT = process.env.DAPP_PORT || 8282;
+const DAPP_HOST = process.env.DAPP_HOST || "0.0.0.0";
+const DAPP_CERT = process.env.DAPP_CERT || "localhost.crt";
+const DAPP_KEY = process.env.DAPP_KEY || "localhost.key";
+
 module.exports = function(grunt) {
 
   // Project configuration.
@@ -13,13 +18,13 @@ module.exports = function(grunt) {
             // the server port
             // can also be written as a function, e.g.
             // port: function() { return 8282; }
-            port: 8282,
+            port: DAPP_PORT,
 
             // the host ip address
             // If specified to, for example, "127.0.0.1" the server will
             // only be available on that ip.
             // Specify "0.0.0.0" to be available everywhere
-            host: "0.0.0.0",
+            host: DAPP_HOST,
 
             // cache: <sec>,
             showDir : true,
@@ -37,13 +42,13 @@ module.exports = function(grunt) {
             // the server port
             // can also be written as a function, e.g.
             // port: function() { return 8282; }
-            port: 8282,
+            port: DAPP_PORT,
 
             // the host ip address
             // If specified to, for example, "127.0.0.1" the server will
             // only be available on that ip.
             // Specify "0.0.0.0" to be available everywhere
-            host: "0.0.0.0",
+            host: DAPP_HOST,
 
             // cache: <sec>,
             showDir : true,
@@ -66,8 +71,8 @@ module.exports = function(grunt) {
             /// Use 'https: true' for default module SSL configuration
             /// (default state is disabled)
             https: {
-                cert: "localhost.crt",
-                key : "localhost.key"
+                cert: DAPP_CERT,
+                key:  DAPP_KEY
             },
             //
             // // Tell grunt task to open the browser


### PR DESCRIPTION
For some reason, the listen host/port are hardcoded, as are the SSL cert/key.

I've converted them into environment variables with defaults, so they can be overriden by the user if they want/need to.

For example, maybe they only want it to listen on `127.0.0.1` / `::1`

Or... they have something else already listening on port `8282` (which is the reason we made this PR!), allowing them to just change the listen port to something else.


Environment vars:

 - `DAPP_PORT` (default 8282)
 - `DAPP_HOST` (default 0.0.0.0)
 - `DAPP_CERT` (default localhost.crt)
 - `DAPP_KEY` (default localhost.key)