### PR TITLE
Correct dev note for executeTransaction

### DIFF
--- a/contracts/MultiSigWallet.sol
+++ b/contracts/MultiSigWallet.sol
@@ -219,7 +219,7 @@ contract MultiSigWallet {
         Revocation(msg.sender, transactionId);
     }
 
-    /// @dev Allows anyone to execute a confirmed transaction.
+    /// @dev Allows an owner to execute a confirmed transaction.
     /// @param transactionId Transaction ID.
     function executeTransaction(uint transactionId)
         public


### PR DESCRIPTION
Only owner is allowed to call "executeTransaction", so we should change "anyone" to "an owner" for this dev note.